### PR TITLE
fix: exclude example dir when publishing modules

### DIFF
--- a/.github/workflows/publish-terraform-module.yaml
+++ b/.github/workflows/publish-terraform-module.yaml
@@ -69,7 +69,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p package
-          rsync -Rr --exclude=".*" --exclude="package" ./ package/${{ inputs.module_name }}
+          rsync -Rr --exclude=".*" --exclude="example" --exclude="package" ./ package/${{ inputs.module_name }}
           cd package/${{ inputs.module_name }}
           jf terraform publish \
             --namespace=nethermind \


### PR DESCRIPTION
There is no need to add the example dir when publishing the module.  Sometimes the example dir will use relative dir to find the module and when someone uses the module it might not be setup properly.

For example: https://github.com/NethermindEth/terragrunt/actions/runs/13924745663/job/38966162701?pr=482#step:6:298