### PR TITLE
feat: enhance Docker promotion and publishing workflows

### DIFF
--- a/.github/workflows/promote-docker.yaml
+++ b/.github/workflows/promote-docker.yaml
@@ -6,8 +6,13 @@ on:
         type: string
         default: 'nethermind.jfrog.io'
         required: false
+      image_name:
+        description: 'Name of the image to publish.  Defaults to the repository name.'
+        type: string
+        required: false
+        default: "${{ github.event.repository.name }}"
       target_env:
-        description: 'Target environment to promote to (staging/prod)'
+        description: 'Target environment to promote to (either staging or prod)'
         type: string
         required: true
       tags:
@@ -27,11 +32,32 @@ jobs:
     name: Promote Docker image
     runs-on: ubuntu-latest
     steps:
+      - name: Validade input
+        run: |
+          if [[ ! "${{ inputs.target_env }}" =~ ^(staging|prod)$ ]]; then
+            echo "Invalid environment. Choose 'staging' or 'prod'"
+            exit 1
+          fi
+
+      - name: Set environment variables
+        run: |
+          SOURCE_ENV=$([[ "${{ inputs.target_env }}" == "staging" ]] && echo "dev" || echo "staging")
+          echo "SOURCE_ENV=${SOURCE_ENV}" >> $GITHUB_ENV
+
+          SOURCE_IMAGE="${{ inputs.jfrog_url }}/${{ secrets.artifactory_username }}-oci-local-${SOURCE_ENV}/${{ inputs.image_name }}"
+          TARGET_IMAGE="${{ inputs.jfrog_url }}/${{ secrets.artifactory_username }}-oci-local-${{ inputs.target_env }}/${{ inputs.image_name }}"
+          echo "SOURCE_IMAGE=${SOURCE_IMAGE}" >> $GITHUB_ENV
+          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> $GITHUB_ENV
+
+
       - name: Checkout code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Setup oras cli
+        uses: oras-project/setup-oras@5c0b487ce3fe0ce3ab0d034e63669e426e294e4d # v1.2.2
 
       - name: Login to Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -43,33 +69,18 @@ jobs:
       - name: Promote Images
         id: promote
         run: |
-          # Determine source environment based on target
-          if [[ "${{ inputs.target_env }}" == "staging" ]]; then
-            SOURCE_ENV="dev"
-          elif [[ "${{ inputs.target_env }}" == "prod" ]]; then
-            SOURCE_ENV="staging"
-          else
-            echo "Error: Invalid target environment. Must be either 'staging' or 'prod'"
-            exit 1
-          fi
-
-          SOURCE_REPO="${{ secrets.artifactory_username }}-oci-local-${SOURCE_ENV}"
-          TARGET_REPO="${{ secrets.artifactory_username }}-oci-local-${{ inputs.target_env }}"
-          
-          IMAGE_NAME="${{ github.event.repository.name }}"
-          
           # Promote all specified tags
           IFS=',' read -ra TAGS <<< "${{ inputs.tags }}"
           for TAG in "${TAGS[@]}"; do
-            source_image="${{ inputs.jfrog_url }}/${SOURCE_REPO}/${IMAGE_NAME}:${TAG}"
-            target_image="${{ inputs.jfrog_url }}/${TARGET_REPO}/${IMAGE_NAME}:${TAG}"
+            source_image="${SOURCE_IMAGE}:${TAG}"
+            target_image="${TARGET_IMAGE}:${TAG}"
             echo "Promoting ${source_image} to ${target_image}"
-            docker buildx imagetools create -t "${target_image}" "${source_image}"
-            
-            # Get digest using docker inspect with json format
+
+            oras cp -r ${source_image} ${target_image}
+
+            # Get image digest and add it to the subject.checksums.txt file
             DIGEST=$(docker buildx imagetools inspect "${target_image}" --raw | sha256sum | cut -d' ' -f1)
-            DIGEST="sha256:${DIGEST}"
-            echo "digest=${DIGEST}" >> $GITHUB_OUTPUT
+            echo "${DIGEST}  ${TAG}" >> subject.checksums.txt
           done
 
       - name: Attest
@@ -77,17 +88,13 @@ jobs:
         id: attest
         with:
           subject-name: ${{ inputs.jfrog_url }}/${{ secrets.artifactory_username }}-oci-local-${{ inputs.target_env }}/${{ github.event.repository.name }}
-          subject-digest: ${{ steps.promote.outputs.digest }}
+          subject-checksums: subject.checksums.txt
           push-to-registry: true
 
       - name: Record Promotion
         run: |
-          SOURCE_ENV=$([[ "${{ inputs.target_env }}" == "staging" ]] && echo "dev" || echo "staging")
-          SOURCE_REPO="${{ secrets.artifactory_username }}-oci-local-${SOURCE_ENV}"
-          TARGET_REPO="${{ secrets.artifactory_username }}-oci-local-${{ inputs.target_env }}"
-          
           echo "## Image Promotion :rocket:" >> $GITHUB_STEP_SUMMARY
-          echo "- From: ${{ inputs.jfrog_url }}/${SOURCE_REPO}/${{ github.event.repository.name }}" >> $GITHUB_STEP_SUMMARY
-          echo "- To: ${{ inputs.jfrog_url }}/${TARGET_REPO}/${{ github.event.repository.name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- From: $SOURCE_IMAGE" >> $GITHUB_STEP_SUMMARY
+          echo "- To: $TARGET_IMAGE" >> $GITHUB_STEP_SUMMARY
           echo "- Tags: ${{ inputs.tags }}" >> $GITHUB_STEP_SUMMARY
           echo "- Timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -2,19 +2,24 @@ on:
   workflow_call:
     inputs:
       jfrog_url:
-        description: 'URL of Artifactory server'
+        description: "URL of Artifactory server"
         type: string
-        default: 'nethermind.jfrog.io'
+        default: "nethermind.jfrog.io"
         required: false
-      context:  
+      image_name:
+        description: "Name of the image to publish.  Defaults to the repository name."
+        type: string
+        required: false
+        default: "${{ github.event.repository.name }}"
+      context:
         description: "Build's context is the set of files located in the specified PATH or URL"
         type: string
-        default: '.'
+        default: "."
         required: false
       platforms:
-        description: 'Platforms to build for (comma-separated)'
+        description: "Platforms to build for (comma-separated)"
         type: string
-        default: 'linux/amd64,linux/arm64'
+        default: "linux/amd64,linux/arm64"
         required: false
       setup-qemu:
         description: "Set up QEMU"
@@ -22,21 +27,21 @@ on:
         default: false
         required: false
       dockerfile_path:
-        description: 'Path to Dockerfile'
+        description: "Path to Dockerfile"
         type: string
-        default: 'Dockerfile'
+        default: "Dockerfile"
         required: false
       additional_tags:
-        description: 'Additional tags to apply (comma-separated)'
+        description: "Additional tags to apply (comma-separated)"
         type: string
-        default: ''
+        default: ""
         required: false
     secrets:
       artifactory_access_token:
-        description: 'A token used to communicate with Artifactory'
+        description: "A token used to communicate with Artifactory"
         required: true
       artifactory_username:
-        description: 'Username for Artifactory authentication'
+        description: "Username for Artifactory authentication"
         required: true
 
 permissions:
@@ -70,7 +75,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
-          images: ${{ inputs.jfrog_url }}/${{ secrets.artifactory_username }}-oci-local-dev/${{ github.event.repository.name }}
+          images: ${{ inputs.jfrog_url }}/${{ secrets.artifactory_username }}-oci-local-dev/${{ inputs.image_name }}
           tags: |
             type=raw,value=latest
             type=ref,event=branch
@@ -84,9 +89,9 @@ jobs:
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile_path }}
-          platforms: linux/amd64
+          platforms: ${{ inputs.platforms }}
           push: false
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: temporary-tag
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -97,39 +102,39 @@ jobs:
         uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # v0.30.0
         with:
           image-ref: ${{ steps.build_no_push.outputs.imageid }}
-          format: 'table'
-          exit-code: '1'
+          format: "table"
+          exit-code: "1"
           ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
           trivyignores: ./.trivyignore
-          output: 'trivy-results.txt'
+          output: "trivy-results.txt"
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_DISABLE_VEX_NOTICE: true
 
       - name: Push to Registry
-        id: build_push
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
-        with:
-          context: ${{ inputs.context }}
-          file: ${{ inputs.dockerfile_path }}
-          platforms: ${{ inputs.platforms }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        run: |
+          TMP_TAG=temporary-tag
+          NEW_TAGS=${{ steps.meta.outputs.tags }}
+          # Process each tag separately by splitting the comma-separated string
+          IFS=',' read -ra TAGS <<< "$NEW_TAGS"
+          for TAG in "${TAGS[@]}"; do
+            if [ -n "$TAG" ]; then
+              echo "Creating image with tag: $TAG"
+              docker buildx imagetools create -t "$TAG" "$TMP_TAG"
+            fi
+          done
 
       - name: Attest
         if: ${{ success() }}
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
         id: attest
         with:
-          subject-name: ${{ inputs.jfrog_url }}/${{ secrets.artifactory_username }}-oci-local-dev/${{ github.event.repository.name }}
-          subject-digest: ${{ steps.build_push.outputs.digest }}
+          subject-name: ${{ steps.meta.outputs.tags }}
+          subject-digest: ${{ steps.build_no_push.outputs.digest }}
           push-to-registry: true
-  
+
       - name: Summary
         if: always()
         run: |

--- a/examples/promote-docker.yml
+++ b/examples/promote-docker.yml
@@ -33,6 +33,7 @@ jobs:
 
       # Optional inputs (with defaults shown)
       jfrog_url: 'nethermind.jfrog.io'
+      image_name: '<repository-name>'
 
     # Required secrets
     secrets:

--- a/examples/publish-docker.yml
+++ b/examples/publish-docker.yml
@@ -27,6 +27,7 @@ jobs:
     with:
       # Optional inputs (with their defaults shown)
       jfrog_url: 'nethermind.jfrog.io'
+      image_name: '<repository-name>'
       platforms: 'linux/amd64,linux/arm64'
       context: '.'
       setup-qemu: false

--- a/examples/publish-multiple-docker.yaml
+++ b/examples/publish-multiple-docker.yaml
@@ -1,0 +1,37 @@
+# Builds and publishes Docker images to JFrog Artifactory
+name: Docker Image Build & Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
+      - '!.github/workflows/**'
+
+permissions:
+  id-token: write
+  attestations: write
+  contents: read
+
+jobs:
+  build_service_a:
+    uses: NethermindEth/github-workflows/.github/workflows/publish-docker.yaml@main
+    with:
+      image_name: 'service-a'
+      context: 'service_a/'
+      dockerfile_path: 'service_a/Dockerfile'
+    secrets:
+      artifactory_access_token: ${{ secrets.ARTIFACTORY_TOKEN }}
+      artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+
+  build_service_b:
+    uses: NethermindEth/github-workflows/.github/workflows/publish-docker.yaml@main
+    with:
+      image_name: 'service-b'
+      context: 'service_b/'
+      dockerfile_path: 'service_b/Dockerfile'
+    secrets:
+      artifactory_access_token: ${{ secrets.ARTIFACTORY_TOKEN }}
+      artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}


### PR DESCRIPTION
- Added `image_name` input to both promote and publish workflows, defaulting to the repository name.
- Implemented input validation for target environment in the promote workflow, ensuring only 'staging' or 'prod' are accepted.
- Stop building the image twice (once to validade and another to push)
- Use oras cli to make it easier to copy OCI images and ALL required artifacts around
- Refactored image promotion logic to utilize environment variables for source and target images, improving clarity and maintainability.
- Updated example YAML files to reflect the new `image_name` input.