### PR TITLE
fix: add missing issues permission for release please

### DIFF
--- a/.github/workflows/job-terraform-release.yaml
+++ b/.github/workflows/job-terraform-release.yaml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   release:


### PR DESCRIPTION
### Description

Without this new workflows are failing with error:
```
Error: release-please failed: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}
```