### PR TITLE
Enhance Docker publish workflows with OIDC support

### DIFF
--- a/.github/workflows/promote-docker.yaml
+++ b/.github/workflows/promote-docker.yaml
@@ -19,13 +19,18 @@ on:
         description: 'Tags to promote (comma-separated)'
         type: string
         required: true
+      login_with_oidc:
+        description: "Login with OIDC.  Set it to true if you want to use OIDC to login to the registry."
+        type: boolean
+        default: false
+        required: false
     secrets:
       artifactory_access_token:
         description: 'A token used to communicate with Artifactory'
-        required: true
+        required: false
       artifactory_username:
         description: 'Username for Artifactory authentication'
-        required: true
+        required: false
 
 jobs:
   promote:
@@ -56,15 +61,33 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      - name: Install JFrog CLI
+        if: ${{ inputs.login_with_oidc }}
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ inputs.jfrog_url }}
+        with:
+          oidc-provider-name: github-nethermindeth
+
       - name: Setup oras cli
         uses: oras-project/setup-oras@8d34698a59f5ffe24821f0b48ab62a3de8b64b20 # v1.2.3
 
       - name: Login to Registry
+        if: ${{ !inputs.login_with_oidc }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: https://${{ inputs.jfrog_url }}
           username: ${{ secrets.artifactory_username }}
           password: ${{ secrets.artifactory_access_token }}
+
+      - name: Login to Registry with OIDC
+        if: ${{ inputs.login_with_oidc }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ inputs.jfrog_url }}
+          username: ${{ steps.jfrog.outputs.oidc-user }}
+          password: ${{ steps.jfrog.outputs.oidc-token }}
 
       - name: Promote Images
         id: promote

--- a/.github/workflows/publish-docker.yaml
+++ b/.github/workflows/publish-docker.yaml
@@ -41,13 +41,18 @@ on:
         type: boolean
         default: false
         required: false
+      login_with_oidc:
+        description: "Login with OIDC.  Set it to true if you want to use OIDC to login to the registry."
+        type: boolean
+        default: false
+        required: false
     secrets:
       artifactory_access_token:
         description: "A token used to communicate with Artifactory"
-        required: true
+        required: false
       artifactory_username:
         description: "Username for Artifactory authentication"
-        required: true
+        required: false
 
 permissions:
   id-token: write
@@ -69,12 +74,30 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      - name: Install JFrog CLI
+        if: ${{ inputs.login_with_oidc }}
+        id: jfrog
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: ${{ inputs.jfrog_url }}
+        with:
+          oidc-provider-name: github-nethermindeth
+
       - name: Login to Registry
+        if: ${{ !inputs.login_with_oidc }}
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           registry: https://${{ inputs.jfrog_url }}
           username: ${{ secrets.artifactory_username }}
           password: ${{ secrets.artifactory_access_token }}
+
+      - name: Login to Registry with OIDC
+        if: ${{ inputs.login_with_oidc }}
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+        with:
+          registry: ${{ inputs.jfrog_url }}
+          username: ${{ steps.jfrog.outputs.oidc-user }}
+          password: ${{ steps.jfrog.outputs.oidc-token }}
 
       - name: Docker meta
         id: meta

--- a/examples/promote-docker.yml
+++ b/examples/promote-docker.yml
@@ -34,8 +34,10 @@ jobs:
       # Optional inputs (with defaults shown)
       jfrog_url: 'nethermind.jfrog.io'
       image_name: '<repository-name>'
+      login_with_oidc: false
 
-    # Required secrets
+    # Optional secrets - Deprecated
+    # Use those secrets if you don't have the OIDC enabled yet
     secrets:
       artifactory_access_token: ${{ secrets.ARTIFACTORY_TOKEN }}     # JFrog access token
       artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}      # Repository prefix, e.g. 'angkor'

--- a/examples/publish-docker.yml
+++ b/examples/publish-docker.yml
@@ -33,8 +33,10 @@ jobs:
       setup-qemu: false
       dockerfile_path: 'Dockerfile'
       additional_tags: ''                      # Example: 'latest,1.0.0'
+      login_with_oidc: false
 
-    # Required secrets
+    # Optional secrets - Deprecated
     secrets:
+      # Use those secrets if you don't have the OIDC enabled yet
       artifactory_access_token: ${{ secrets.ARTIFACTORY_TOKEN }}     # JFrog access token
       artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}      # Repository prefix, e.g. 'angkor'

--- a/examples/publish-multiple-docker.yaml
+++ b/examples/publish-multiple-docker.yaml
@@ -22,9 +22,7 @@ jobs:
       image_name: 'service-a'
       context: 'service_a/'
       dockerfile_path: 'service_a/Dockerfile'
-    secrets:
-      artifactory_access_token: ${{ secrets.ARTIFACTORY_TOKEN }}
-      artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      login_with_oidc: true
 
   build_service_b:
     uses: NethermindEth/github-workflows/.github/workflows/publish-docker.yaml@main
@@ -32,6 +30,4 @@ jobs:
       image_name: 'service-b'
       context: 'service_b/'
       dockerfile_path: 'service_b/Dockerfile'
-    secrets:
-      artifactory_access_token: ${{ secrets.ARTIFACTORY_TOKEN }}
-      artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+      login_with_oidc: true


### PR DESCRIPTION
- Added `login_with_oidc` input to enable OIDC login for Docker registry.
- Updated secrets for Artifactory to be optional.
- Modified example workflows to reflect changes in OIDC configuration.

This update improves flexibility in authentication methods for Docker publishing.