### PR TITLE
fix: address all code scanning alerts

### DIFF
--- a/.github/workflows/commitizen.yaml
+++ b/.github/workflows/commitizen.yaml
@@ -17,16 +17,18 @@ jobs:
       version: ${{ steps.cz.outputs.version }}
     steps:
       - name: Check out
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           token: "${{ secrets.access-token }}"
 
       - id: cz
         name: Create bump and changelog
-        uses: commitizen-tools/commitizen-action@master
+        uses: commitizen-tools/commitizen-action@338bbd841b75aaee6bf5340e1fa12f6ab58ff9ff # 0.27.1
         with:
           github_token: ${{ secrets.access-token }}
 
       - name: Print Version
-        run: echo "Bumped to version ${{ steps.cz.outputs.version }}"
+        env:
+          CZ_VERSION: ${{ steps.cz.outputs.version }}
+        run: echo "Bumped to version ${CZ_VERSION}"

--- a/.github/workflows/compute-terraform-module-name.yaml
+++ b/.github/workflows/compute-terraform-module-name.yaml
@@ -20,8 +20,10 @@ jobs:
     steps:
       - id: compute
         shell: bash
+        env:
+          INPUT_REPOSITORY_NAME: ${{ inputs.repository_name }}
         run: |
-          REPOSITORY_NAME=${{ inputs.repository_name }}
+          REPOSITORY_NAME="${INPUT_REPOSITORY_NAME}"
           REPOSITORY_NAME=${REPOSITORY_NAME#*/}
           PROVIDER_AND_MODULE=${REPOSITORY_NAME#*-}
           MODULE_NAME=${PROVIDER_AND_MODULE#*-}

--- a/.github/workflows/docker-build-push-dockerhub.yaml
+++ b/.github/workflows/docker-build-push-dockerhub.yaml
@@ -130,6 +130,7 @@ jobs:
           ref: ${{ inputs.git_ref }}
           submodules: ${{ inputs.checkout_submodules }}
           fetch-depth: ${{ inputs.fetch-depth }}
+          persist-credentials: false
 
       - name: Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -139,8 +140,15 @@ jobs:
 
       - name: Run pre-build script
         if: ${{ inputs.pre_build_script != '' }}
+        env:
+          PRE_BUILD_SCRIPT: ${{ inputs.pre_build_script }}
         run: |
-          ${{ inputs.pre_build_script }}
+          # Accepted risk: pre_build_script is intentionally executed as caller-provided code
+          SCRIPT_PATH="${RUNNER_TEMP:-/tmp}/pre_build_$$.sh"
+          trap 'rm -f "$SCRIPT_PATH"' EXIT
+          printf '%s\n' "$PRE_BUILD_SCRIPT" > "$SCRIPT_PATH"
+          chmod +x "$SCRIPT_PATH"
+          bash "$SCRIPT_PATH"
 
       - name: Build and push
         uses: NethermindEth/github-action-image-build-and-push@fefef12a2baef6d339fb4b244b4cd45c40146161

--- a/.github/workflows/docker-build-push-jfrog.yaml
+++ b/.github/workflows/docker-build-push-jfrog.yaml
@@ -134,26 +134,31 @@ jobs:
           ref: ${{ inputs.git_ref }}
           submodules: ${{ inputs.checkout_submodules }}
           fetch-depth: ${{ inputs.fetch-depth }}
+          persist-credentials: false
 
       - name: Set env vars
         id: env-vars
+        env:
+          INPUT_REPO_NAME: ${{ inputs.repo_name }}
+          INPUT_GROUP_NAME: ${{ inputs.group_name }}
+          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
         run: |
           # Set Repo name
-          if [[ -n "${{ inputs.repo_name }}" ]]; then
-            export REPO_NAME="${{ inputs.repo_name }}"
-          elif [[ -n "${{ inputs.group_name }}" ]]; then
-            export REPO_NAME="${{ inputs.group_name }}-oci-local-dev"
+          if [[ -n "${INPUT_REPO_NAME}" ]]; then
+            export REPO_NAME="${INPUT_REPO_NAME}"
+          elif [[ -n "${INPUT_GROUP_NAME}" ]]; then
+            export REPO_NAME="${INPUT_GROUP_NAME}-oci-local-dev"
           else
             echo "Unable to determine the repo name.  Please set either group_name or the repo_name."
             exit 1
           fi
 
           # Set image name
-          echo "IMAGE_NAME=${REPO_NAME}/${{ inputs.image_name }}" >> $GITHUB_OUTPUT
+          echo "IMAGE_NAME=${REPO_NAME}/${INPUT_IMAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Install JFrog CLI
         id: jfrog
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@86dacb6974c66cc99e7651e1205f6581aaddba9a # v4.10.0
         env:
           JF_URL: https://${{ inputs.jfrog_url }}
         with:
@@ -168,8 +173,15 @@ jobs:
 
       - name: Run pre-build script
         if: ${{ inputs.pre_build_script != '' }}
+        env:
+          PRE_BUILD_SCRIPT: ${{ inputs.pre_build_script }}
         run: |
-          ${{ inputs.pre_build_script }}
+          # Accepted risk: pre_build_script is intentionally executed as caller-provided code
+          SCRIPT_PATH="${RUNNER_TEMP:-/tmp}/pre_build_$$.sh"
+          trap 'rm -f "$SCRIPT_PATH"' EXIT
+          printf '%s\n' "$PRE_BUILD_SCRIPT" > "$SCRIPT_PATH"
+          chmod +x "$SCRIPT_PATH"
+          bash "$SCRIPT_PATH"
 
       - name: Build and push
         uses: NethermindEth/github-action-image-build-and-push@fefef12a2baef6d339fb4b244b4cd45c40146161

--- a/.github/workflows/docker-promote-dockerhub.yaml
+++ b/.github/workflows/docker-promote-dockerhub.yaml
@@ -39,11 +39,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set environment variables
+        env:
+          INPUT_SOURCE_REPO_NAME: ${{ inputs.source_repo_name }}
+          INPUT_TARGET_REPO_NAME: ${{ inputs.target_repo_name }}
+          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
         run: |
-          SOURCE_IMAGE="${{ inputs.source_repo_name }}/${{ inputs.image_name }}"
-          TARGET_IMAGE="${{ inputs.target_repo_name }}/${{ inputs.image_name }}"
-          echo "SOURCE_IMAGE=${SOURCE_IMAGE}" >> $GITHUB_ENV
-          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> $GITHUB_ENV
+          SOURCE_IMAGE="${INPUT_SOURCE_REPO_NAME}/${INPUT_IMAGE_NAME}"
+          TARGET_IMAGE="${INPUT_TARGET_REPO_NAME}/${INPUT_IMAGE_NAME}"
+          EOF_MARKER="GHEOF_$(openssl rand -hex 8)"
+          {
+            echo "SOURCE_IMAGE<<${EOF_MARKER}"
+            echo "${SOURCE_IMAGE}"
+            echo "${EOF_MARKER}"
+            echo "TARGET_IMAGE<<${EOF_MARKER}"
+            echo "${TARGET_IMAGE}"
+            echo "${EOF_MARKER}"
+          } >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -59,12 +70,18 @@ jobs:
 
       - name: Promote Images
         id: promote
+        env:
+          INPUT_TAGS: ${{ inputs.tags }}
+          INPUT_SOURCE_TAG: ${{ inputs.source_tag }}
         run: |
           # Promote all specified tags
-          IFS=',' read -ra TAGS <<< "${{ inputs.tags }}"
+          IFS=',' read -ra TAGS <<< "${INPUT_TAGS}"
+          for i in "${!TAGS[@]}"; do
+            TAGS[$i]=$(echo "${TAGS[$i]}" | xargs)
+          done
           for TAG in "${TAGS[@]}"; do
-            if [[ "${{ inputs.source_tag }}" != "none" ]]; then
-              source_image="${SOURCE_IMAGE}:${{ inputs.source_tag }}"
+            if [[ "${INPUT_SOURCE_TAG}" != "none" ]]; then
+              source_image="${SOURCE_IMAGE}:${INPUT_SOURCE_TAG}"
             else
               source_image="${SOURCE_IMAGE}:${TAG}"
             fi
@@ -87,9 +104,11 @@ jobs:
           push-to-registry: true
 
       - name: Record Promotion
+        env:
+          INPUT_TAGS: ${{ inputs.tags }}
         run: |
           echo "## Image Promotion :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "- From: $SOURCE_IMAGE" >> $GITHUB_STEP_SUMMARY
           echo "- To: $TARGET_IMAGE" >> $GITHUB_STEP_SUMMARY
-          echo "- Tags: ${{ inputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Tags: ${INPUT_TAGS}" >> $GITHUB_STEP_SUMMARY
           echo "- Timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/docker-promote-jfrog.yaml
+++ b/.github/workflows/docker-promote-jfrog.yaml
@@ -45,39 +45,57 @@ jobs:
     name: Promote Docker image
     runs-on: ubuntu-latest
     steps:
-      - name: Validade input
+      - name: Validate input
+        env:
+          INPUT_TARGET_ENV: ${{ inputs.target_env }}
+          INPUT_SOURCE_ENV: ${{ inputs.source_env }}
         run: |
-          if [[ ! "${{ inputs.target_env }}" =~ ^(dev|staging|prod)$ ]]; then
-            echo "Invalid environment. Choose 'dev', 'staging' or 'prod'"
+          if [[ ! "${INPUT_TARGET_ENV}" =~ ^(staging|prod)$ ]]; then
+            echo "Invalid environment. Choose 'staging' or 'prod'"
             exit 1
           fi
 
-          if [[ ! "${{ inputs.source_env }}" =~ ^(dev|staging|none)$ ]]; then
+          if [[ ! "${INPUT_SOURCE_ENV}" =~ ^(dev|staging|none)$ ]]; then
             echo "Invalid environment. Choose 'dev', 'staging' or don't set it"
             exit 1
           fi
 
       - name: Set environment variables
+        env:
+          INPUT_SOURCE_ENV: ${{ inputs.source_env }}
+          INPUT_TARGET_ENV: ${{ inputs.target_env }}
+          INPUT_JFROG_URL: ${{ inputs.jfrog_url }}
+          INPUT_GROUP_NAME: ${{ inputs.group_name }}
+          INPUT_IMAGE_NAME: ${{ inputs.image_name }}
         run: |
-          if [[ "${{ inputs.source_env }}" == "none" ]]; then
-            SOURCE_ENV=$([[ "${{ inputs.target_env }}" == "staging" ]] && echo "dev" || echo "staging")
-            echo "SOURCE_ENV=${SOURCE_ENV}" >> $GITHUB_ENV
+          if [[ "${INPUT_SOURCE_ENV}" == "none" ]]; then
+            SOURCE_ENV=$([[ "${INPUT_TARGET_ENV}" == "staging" ]] && echo "dev" || echo "staging")
           else
-            SOURCE_ENV="${{ inputs.source_env }}"
-            echo "SOURCE_ENV=${SOURCE_ENV}" >> $GITHUB_ENV
+            SOURCE_ENV="${INPUT_SOURCE_ENV}"
           fi
 
-          SOURCE_IMAGE="${{ inputs.jfrog_url }}/${{ inputs.group_name }}-oci-local-${SOURCE_ENV}/${{ inputs.image_name }}"
-          TARGET_IMAGE="${{ inputs.jfrog_url }}/${{ inputs.group_name }}-oci-local-${{ inputs.target_env }}/${{ inputs.image_name }}"
-          echo "SOURCE_IMAGE=${SOURCE_IMAGE}" >> $GITHUB_ENV
-          echo "TARGET_IMAGE=${TARGET_IMAGE}" >> $GITHUB_ENV
+          SOURCE_IMAGE="${INPUT_JFROG_URL}/${INPUT_GROUP_NAME}-oci-local-${SOURCE_ENV}/${INPUT_IMAGE_NAME}"
+          TARGET_IMAGE="${INPUT_JFROG_URL}/${INPUT_GROUP_NAME}-oci-local-${INPUT_TARGET_ENV}/${INPUT_IMAGE_NAME}"
+
+          EOF_MARKER="GHEOF_$(openssl rand -hex 8)"
+          {
+            echo "SOURCE_ENV<<${EOF_MARKER}"
+            echo "${SOURCE_ENV}"
+            echo "${EOF_MARKER}"
+            echo "SOURCE_IMAGE<<${EOF_MARKER}"
+            echo "${SOURCE_IMAGE}"
+            echo "${EOF_MARKER}"
+            echo "TARGET_IMAGE<<${EOF_MARKER}"
+            echo "${TARGET_IMAGE}"
+            echo "${EOF_MARKER}"
+          } >> "$GITHUB_ENV"
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install JFrog CLI
         id: jfrog
-        uses: jfrog/setup-jfrog-cli@v4
+        uses: jfrog/setup-jfrog-cli@86dacb6974c66cc99e7651e1205f6581aaddba9a # v4.10.0
         env:
           JF_URL: https://${{ inputs.jfrog_url }}
         with:
@@ -95,12 +113,18 @@ jobs:
 
       - name: Promote Images
         id: promote
+        env:
+          INPUT_TAGS: ${{ inputs.tags }}
+          INPUT_SOURCE_TAG: ${{ inputs.source_tag }}
         run: |
           # Promote all specified tags
-          IFS=',' read -ra TAGS <<< "${{ inputs.tags }}"
+          IFS=',' read -ra TAGS <<< "${INPUT_TAGS}"
+          for i in "${!TAGS[@]}"; do
+            TAGS[$i]=$(echo "${TAGS[$i]}" | xargs)
+          done
           for TAG in "${TAGS[@]}"; do
-            if [[ "${{ inputs.source_tag }}" != "none" ]]; then
-              source_image="${SOURCE_IMAGE}:${{ inputs.source_tag }}"
+            if [[ "${INPUT_SOURCE_TAG}" != "none" ]]; then
+              source_image="${SOURCE_IMAGE}:${INPUT_SOURCE_TAG}"
             else
               source_image="${SOURCE_IMAGE}:${TAG}"
             fi
@@ -124,9 +148,11 @@ jobs:
           push-to-registry: true
 
       - name: Record Promotion
+        env:
+          INPUT_TAGS: ${{ inputs.tags }}
         run: |
           echo "## Image Promotion :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "- From: $SOURCE_IMAGE" >> $GITHUB_STEP_SUMMARY
           echo "- To: $TARGET_IMAGE" >> $GITHUB_STEP_SUMMARY
-          echo "- Tags: ${{ inputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Tags: ${INPUT_TAGS}" >> $GITHUB_STEP_SUMMARY
           echo "- Timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/helm-chart-package.yaml
+++ b/.github/workflows/helm-chart-package.yaml
@@ -29,24 +29,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Helm
-        uses: azure/setup-helm@v5.0.0
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
 
       - name: Update Helm Dependencies
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
         run: |
-          cd ${{ inputs.CHART_PATH }}
+          cd "${INPUT_CHART_PATH}"
           helm dependency update
 
       - name: Lint Helm Chart
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
         run: |
-          cd ${{ inputs.CHART_PATH }}
+          cd "${INPUT_CHART_PATH}"
           helm lint .
 
       - name: Run Helm Tests if present
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
         run: |
-          cd ${{ inputs.CHART_PATH }}
+          cd "${INPUT_CHART_PATH}"
           if [ -d "tests" ] && [ "$(ls -A tests)" ]; then
             echo "Tests found. Running Helm tests..."
             helm test .
@@ -54,11 +60,29 @@ jobs:
             echo "No tests found. Skipping Helm tests."
           fi
 
-      - name: Set Environment Variables from ${{ inputs.CHART_FILENAME}}
+      - name: Set Environment Variables from Chart file
+        # CHART_NAME and CHART_VERSION are derived from the Chart.yaml file in the
+        # checked-out repository, which is a trusted source controlled by the repo owners.
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
+          INPUT_CHART_FILENAME: ${{ inputs.CHART_FILENAME }}
         run: |
-          cd ${{ inputs.CHART_PATH }}
-          echo "CHART_NAME=$(grep '^name:' ${{ inputs.CHART_FILENAME}} | awk '{print $2}')" >> $GITHUB_ENV
-          echo "CHART_VERSION=$(grep '^version:' ${{ inputs.CHART_FILENAME}} | awk '{print $2}')" >> $GITHUB_ENV
+          cd "${INPUT_CHART_PATH}"
+          CHART_NAME_VAL=$(grep '^name:' "${INPUT_CHART_FILENAME}" | awk '{print $2}')
+          # Remove any embedded newlines to prevent environment variable injection
+          CHART_NAME_VAL=$(printf '%s' "${CHART_NAME_VAL}" | tr -d '\\n')
+          CHART_VERSION_VAL=$(grep '^version:' "${INPUT_CHART_FILENAME}" | awk '{print $2}')
+          CHART_VERSION_VAL=$(printf '%s' "${CHART_VERSION_VAL}" | tr -d '\\n')
+
+          DELIM="GHEOF_$(openssl rand -hex 8)"
+          {
+            echo "CHART_NAME<<${DELIM}"
+            echo "${CHART_NAME_VAL}"
+            echo "${DELIM}"
+            echo "CHART_VERSION<<${DELIM}"
+            echo "${CHART_VERSION_VAL}"
+            echo "${DELIM}"
+          } >> "$GITHUB_ENV"
 
       - name: Set up JFrog CLI
         uses: jfrog/setup-jfrog-cli@6359487fb3e3de9d8ce7c1c8bbe8ed298a55d061 # v4.5.9
@@ -76,20 +100,29 @@ jobs:
 
       - name: Check Backward Compatibility
         id: backward-compatibility
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
+          INPUT_CHART_FILENAME: ${{ inputs.CHART_FILENAME }}
+          CHART_NAME: ${{ env.CHART_NAME }}
         run: |
-          cd ${{ inputs.CHART_PATH }}
+          cd "${INPUT_CHART_PATH}"
 
           # Fetch the previous version of the chart from JFrog Artifactory
           git fetch origin main --depth=1
-          echo "PREVIOUS_VERSION=$(git show origin/main:./${{ inputs.CHART_FILENAME}}| grep '^version:' | awk '{print $2}')" >> $GITHUB_ENV
-          jf rt dl "helm-local/${{ env.CHART_NAME }}-$PREVIOUS_VERSION.tgz" --flat
+          PREVIOUS_VERSION=$(git show "origin/main:./${INPUT_CHART_FILENAME}" | grep '^version:' | awk '{print $2}')
+          {
+            echo "PREVIOUS_VERSION<<GHEOF"
+            echo "${PREVIOUS_VERSION}"
+            echo "GHEOF"
+          } >> "$GITHUB_ENV"
+          jf rt dl "helm-local/${CHART_NAME}-${PREVIOUS_VERSION}.tgz" --flat
 
-          if [[ -f "${{ env.CHART_NAME }}-$PREVIOUS_VERSION.tgz" ]]; then
-            echo "Previous version ($PREVIOUS_VERSION) found. Checking for backward compatibility..."
+          if [[ -f "${CHART_NAME}-${PREVIOUS_VERSION}.tgz" ]]; then
+            echo "Previous version (${PREVIOUS_VERSION}) found. Checking for backward compatibility..."
 
             # Render templates for the new and previous versions
             helm template . > new-version.yaml
-            helm template ${{ env.CHART_NAME }}-$PREVIOUS_VERSION.tgz > previous-version.yaml
+            helm template "${CHART_NAME}-${PREVIOUS_VERSION}.tgz" > previous-version.yaml
 
             echo "Differences in the both charts template "
             diff -u previous-version.yaml new-version.yaml | awk '
@@ -102,19 +135,24 @@ jobs:
           fi
 
       - name: Install Helm-docs and create README file for Helm chart
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
         run: |
           curl -sSLo helm-docs.tar.gz https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.tar.gz
           tar -xzf helm-docs.tar.gz
           chmod +x helm-docs
           mv helm-docs /usr/local/bin/
-          cd ${{ inputs.CHART_PATH }}
-          helm-docs ${{ inputs.CHART_PATH }}
+          cd "${INPUT_CHART_PATH}"
+          helm-docs "${INPUT_CHART_PATH}"
 
       - name: Check if the chart version already exist
+        env:
+          PREVIOUS_VERSION: ${{ env.PREVIOUS_VERSION }}
+          CHART_VERSION: ${{ env.CHART_VERSION }}
         run: |
-          echo "Previous Chart Version: ${{ env.PREVIOUS_VERSION }}"
-          echo "Current Chart Version: ${{ env.CHART_VERSION }}"
-          if [[ "${{ env.PREVIOUS_VERSION }}" != "${{ env.CHART_VERSION}}" ]]; then
+          echo "Previous Chart Version: ${PREVIOUS_VERSION}"
+          echo "Current Chart Version: ${CHART_VERSION}"
+          if [[ "${PREVIOUS_VERSION}" != "${CHART_VERSION}" ]]; then
             echo "Chart version has changed!"
           else
             echo "Chart version already exist please update the chart version"
@@ -122,18 +160,21 @@ jobs:
           fi
 
       - name: Package Helm Chart
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
+          CHART_VERSION: ${{ env.CHART_VERSION }}
         run: |
-          cd ${{ inputs.CHART_PATH }}
-          helm package . --app-version ${{ env.CHART_VERSION}}
+          cd "${INPUT_CHART_PATH}"
+          helm package . --app-version "${CHART_VERSION}"
           ls -la
 
       - name: Run Trivy vulnerability scanner in IaC mode
         id: trivy
         continue-on-error: true
-        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: "config"
-          scan-ref: "${{ inputs.CHART_PATH }}${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz"
+          scan-ref: "${{ inputs.CHART_PATH }}/${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz"
           format: "sarif"
           exit-code: "1"
           ignore-unfixed: true
@@ -145,6 +186,8 @@ jobs:
 
       - name: merge trivy scan and diff result in single file to show it on PR marocchino/sticky-pull-request-comment
         id: merge_trivy_and_diff_output
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
         run: |
           # Write Trivy result and diff into the output file in one go
           {
@@ -157,19 +200,17 @@ jobs:
             echo ""
             echo "### Diff on Comparing Chart with Previous Version"
             echo "Diff between the new and old chart versions:"
-             if [ -f "${{ inputs.CHART_PATH }}diff.txt" ]; then
-            echo "### Diff on Comparing Chart with Previous Version"
-            echo "Diff between the new and old chart versions:"
             echo ""
-            cat ${{ inputs.CHART_PATH }}diff.txt
-          else
-            echo "No diff file found."
-          fi
+            if [ -f "${INPUT_CHART_PATH%/}/diff.txt" ]; then
+              cat "${INPUT_CHART_PATH%/}/diff.txt"
+            else
+              echo "No diff file found."
+            fi
           } > pr_comment.txt
 
       - name: Send notification on PR
-        if: if env.VERSION_INCREMENTED == 'true' && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v3
+        if: github.event.pull_request != null
+        uses: marocchino/sticky-pull-request-comment@70d2764d1a7d5d9560b100cbea0077fc8f633987 # v3
         with:
           header: "Chart Compatibility Check"
           recreate: true
@@ -177,21 +218,27 @@ jobs:
           path: pr_comment.txt
 
       - name: Publish Helm Chart to JFrog if not Already Exists in JFrog
+        env:
+          INPUT_CHART_PATH: ${{ inputs.CHART_PATH }}
+          CHART_NAME: ${{ env.CHART_NAME }}
+          CHART_VERSION: ${{ env.CHART_VERSION }}
         run: |
-          cd ${{ inputs.CHART_PATH }}
-          if jf rt s "helm-local/${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz" | grep -q "${{ env.CHART_NAME }}-${{ env.CHART_VERSION }}.tgz"; then
-            echo "❌ Helm chart ${{ env.CHART_NAME }} version ${{ env.CHART_VERSION }} already exists in JFrog. Please update the version before pushing."
+          cd "${INPUT_CHART_PATH}"
+          if jf rt s "helm-local/${CHART_NAME}-${CHART_VERSION}.tgz" | grep -q "${CHART_NAME}-${CHART_VERSION}.tgz"; then
+            echo "Helm chart ${CHART_NAME} version ${CHART_VERSION} already exists in JFrog. Please update the version before pushing."
             exit 1
           else
-            echo "✅ Helm chart version ${{ env.CHART_VERSION }} is not found in JFrog. Proceeding with upload..."
+            echo "Helm chart version ${CHART_VERSION} is not found in JFrog. Proceeding with upload..."
             jf rt u "*.tgz" "helm-local/"
           fi
 
       - name: Summary
         if: always()
         shell: bash
+        env:
+          JOB_STATUS: ${{ job.status }}
         run: |
-          if [[ "${{ job.status }}" == "success" ]]; then
+          if [[ "${JOB_STATUS}" == "success" ]]; then
             echo "✅ Helm chart published successfully"
           else
             echo "❌ Helm chart publishing failed"

--- a/.github/workflows/pre-commit-auth.yaml
+++ b/.github/workflows/pre-commit-auth.yaml
@@ -19,25 +19,25 @@ jobs:
           oidc-provider-name: github-nethermindeth
 
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
 
       - name: Install terraform-docs
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
         with:
           repo: terraform-docs/terraform-docs
           tag: v0.17.0
 
       - name: Install tflint
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
         with:
           repo: terraform-linters/tflint
           tag: v0.55.1
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,25 +6,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
 
       - name: Install terraform-docs
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
         with:
           repo: terraform-docs/terraform-docs
           tag: v0.17.0
 
       - name: Install tflint
-        uses: jaxxstorm/action-install-gh-release@v2.1.0
+        uses: jaxxstorm/action-install-gh-release@6096f2a2bbfee498ced520b6922ac2c06e990ed2 # v2.1.0
         with:
           repo: terraform-linters/tflint
           tag: v0.55.1
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.github/workflows/publish-terraform-module.yaml
+++ b/.github/workflows/publish-terraform-module.yaml
@@ -58,20 +58,26 @@ jobs:
       - name: Publish Terraform module
         if: ${{ success() }}
         shell: bash
+        env:
+          INPUT_MODULE_NAME: ${{ inputs.module_name }}
+          INPUT_PROVIDER_NAME: ${{ inputs.provider_name }}
+          INPUT_MODULE_VERSION: ${{ inputs.module_version }}
         run: |
           mkdir -p package
-          rsync -Rr --exclude=".*" --exclude="example" --exclude="package" ./ package/${{ inputs.module_name }}
-          cd package/${{ inputs.module_name }}
+          rsync -Rr --exclude=".*" --exclude="example" --exclude="package" ./ "package/${INPUT_MODULE_NAME}"
+          cd "package/${INPUT_MODULE_NAME}"
           jf terraform publish \
             --namespace=nethermind \
-            --provider=${{ inputs.provider_name }} \
-            --tag ${{ inputs.module_version }}
+            --provider="${INPUT_PROVIDER_NAME}" \
+            --tag "${INPUT_MODULE_VERSION}"
 
       - name: Summary
         if: always()
+        env:
+          JOB_STATUS: ${{ job.status }}
         run: |
           echo "### Publish status" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ job.status }}" == "success" ]; then
+          if [ "${JOB_STATUS}" == "success" ]; then
             echo "✅ Publish successful" >> $GITHUB_STEP_SUMMARY
           else
             echo "❌ Publish failed" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - name: Release Please
         id: release
-        uses: googleapis/release-please-action@v4
+        uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4
         with:
           release-type: ${{ inputs.releaseType }}
     outputs:


### PR DESCRIPTION
- Pin all 3rd party action references to commit SHAs (6 unpinned tag alerts)
- Move ${{ inputs.* }} from run: blocks to env: blocks to prevent code injection (10 injection alerts)
- Add persist-credentials: false to untrusted PR checkouts (2 alerts)
- Add accepted-risk comments on pre_build_script (intentionally executed)