### PR TITLE
fix: resolve Docker build workflow warnings

### DIFF
--- a/.github/workflows/docker-build-push-dockerhub.yaml
+++ b/.github/workflows/docker-build-push-dockerhub.yaml
@@ -115,6 +115,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:
@@ -151,7 +152,7 @@ jobs:
           bash "$SCRIPT_PATH"
 
       - name: Build and push
-        uses: NethermindEth/github-action-image-build-and-push@fefef12a2baef6d339fb4b244b4cd45c40146161
+        uses: NethermindEth/github-action-image-build-and-push@972f8cf69d5ede0a0cb9d7cc953fa902538e2ffa
         with:
           registry: "dockerhub"
           image_name: ${{ inputs.repo_name }}/${{ inputs.image_name }}

--- a/.github/workflows/docker-build-push-jfrog.yaml
+++ b/.github/workflows/docker-build-push-jfrog.yaml
@@ -119,6 +119,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:
@@ -184,7 +185,7 @@ jobs:
           bash "$SCRIPT_PATH"
 
       - name: Build and push
-        uses: NethermindEth/github-action-image-build-and-push@fefef12a2baef6d339fb4b244b4cd45c40146161
+        uses: NethermindEth/github-action-image-build-and-push@972f8cf69d5ede0a0cb9d7cc953fa902538e2ffa
         with:
           registry: "artifactory"
           image_name: ${{ steps.env-vars.outputs.IMAGE_NAME }}

--- a/.github/workflows/docker-promote-dockerhub.yaml
+++ b/.github/workflows/docker-promote-dockerhub.yaml
@@ -33,6 +33,12 @@ on:
         description: "Docker Hub password"
         required: true
 
+permissions:
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+  contents: read
+
 jobs:
   promote:
     name: Promote Docker image

--- a/.github/workflows/docker-promote-jfrog.yaml
+++ b/.github/workflows/docker-promote-jfrog.yaml
@@ -40,6 +40,12 @@ on:
         required: false
         default: false
 
+permissions:
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+  contents: read
+
 jobs:
   promote:
     name: Promote Docker image

--- a/examples/docker/build-push-dockehub-complete.yml
+++ b/examples/docker/build-push-dockehub-complete.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:

--- a/examples/docker/build-push-dockerhub-simple.yml
+++ b/examples/docker/build-push-dockerhub-simple.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:

--- a/examples/docker/build-push-jfrog-complete.yml
+++ b/examples/docker/build-push-jfrog-complete.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:

--- a/examples/docker/build-push-jfrog-simple.yml
+++ b/examples/docker/build-push-jfrog-simple.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:

--- a/examples/docker/docker-push-multiple-jfrog.yaml
+++ b/examples/docker/docker-push-multiple-jfrog.yaml
@@ -8,6 +8,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:

--- a/examples/docker/promote-dockerhub.yml
+++ b/examples/docker/promote-dockerhub.yml
@@ -15,6 +15,7 @@ concurrency:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:

--- a/examples/docker/promote-jfrog.yml
+++ b/examples/docker/promote-jfrog.yml
@@ -20,6 +20,7 @@ concurrency:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:


### PR DESCRIPTION
## Summary
- Add `artifact-metadata: write` permission to all Docker build/promote workflows and examples (new [GA permission since Jan 2026](https://github.blog/changelog/2026-01-13-new-fine-grained-permission-for-artifact-metadata-is-now-generally-available/))
- Bump `github-action-image-build-and-push` to pick up the `actions/cache` v4→v5 update (fixes Node.js 20 deprecation warning)
- Add missing `permissions` block to promote workflows that use `actions/attest-build-provenance`

Fixes warnings from: https://github.com/NethermindEth/angkor-platform-api/actions/runs/24246678153

## Test plan
- [ ] Verify Docker build workflow runs without `artifact-metadata:write` warning
- [ ] Verify no "Failed to create storage record" error
- [ ] Verify no Node.js 20 deprecation warning for `actions/cache`