### PR TITLE
fix: remove artifact-metadata:write from reusable workflows

### DIFF
--- a/.github/workflows/docker-build-push-dockerhub.yaml
+++ b/.github/workflows/docker-build-push-dockerhub.yaml
@@ -115,7 +115,6 @@ on:
 permissions:
   id-token: write
   attestations: write
-  artifact-metadata: write
   contents: read
 
 jobs:

--- a/.github/workflows/docker-build-push-jfrog.yaml
+++ b/.github/workflows/docker-build-push-jfrog.yaml
@@ -119,7 +119,6 @@ on:
 permissions:
   id-token: write
   attestations: write
-  artifact-metadata: write
   contents: read
 
 jobs:

--- a/.github/workflows/docker-promote-dockerhub.yaml
+++ b/.github/workflows/docker-promote-dockerhub.yaml
@@ -33,12 +33,6 @@ on:
         description: "Docker Hub password"
         required: true
 
-permissions:
-  id-token: write
-  attestations: write
-  artifact-metadata: write
-  contents: read
-
 jobs:
   promote:
     name: Promote Docker image

--- a/.github/workflows/docker-promote-jfrog.yaml
+++ b/.github/workflows/docker-promote-jfrog.yaml
@@ -40,12 +40,6 @@ on:
         required: false
         default: false
 
-permissions:
-  id-token: write
-  attestations: write
-  artifact-metadata: write
-  contents: read
-
 jobs:
   promote:
     name: Promote Docker image


### PR DESCRIPTION
## Summary
- Remove `artifact-metadata: write` from the 4 reusable workflows (build + promote) to avoid breaking callers that don't yet grant this permission
- Reusable workflows cannot request permissions the caller doesn't provide — GitHub fails with a validation error
- The permission remains in the **example files** so callers can adopt it at their own pace

Follows up on #141.

## Test plan
- [ ] Verify existing caller workflows (e.g. angkor-platform-api) still pass without adding `artifact-metadata: write`