### PR TITLE
feat!: require artifact-metadata:write permission for attestations

### DIFF
--- a/.github/workflows/docker-build-push-dockerhub.yaml
+++ b/.github/workflows/docker-build-push-dockerhub.yaml
@@ -115,6 +115,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:

--- a/.github/workflows/docker-build-push-jfrog.yaml
+++ b/.github/workflows/docker-build-push-jfrog.yaml
@@ -119,6 +119,7 @@ on:
 permissions:
   id-token: write
   attestations: write
+  artifact-metadata: write
   contents: read
 
 jobs:

--- a/.github/workflows/docker-promote-dockerhub.yaml
+++ b/.github/workflows/docker-promote-dockerhub.yaml
@@ -33,6 +33,12 @@ on:
         description: "Docker Hub password"
         required: true
 
+permissions:
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+  contents: read
+
 jobs:
   promote:
     name: Promote Docker image

--- a/.github/workflows/docker-promote-jfrog.yaml
+++ b/.github/workflows/docker-promote-jfrog.yaml
@@ -40,6 +40,12 @@ on:
         required: false
         default: false
 
+permissions:
+  id-token: write
+  attestations: write
+  artifact-metadata: write
+  contents: read
+
 jobs:
   promote:
     name: Promote Docker image


### PR DESCRIPTION
## Summary
- Add `artifact-metadata: write` to all Docker build and promote reusable workflows
- Required by `actions/attest-build-provenance` since [GitHub made the permission GA in Jan 2026](https://github.blog/changelog/2026-01-13-new-fine-grained-permission-for-artifact-metadata-is-now-generally-available/)

## Breaking Change
Caller workflows with explicit `permissions:` blocks must add `artifact-metadata: write`:

```yaml
permissions:
  id-token: write
  attestations: write
  artifact-metadata: write  # ← add this
  contents: read
```

Without it, GitHub will reject the workflow with a validation error.

## Test plan
- [ ] Verify caller workflows updated with the new permission pass
- [ ] Verify the `artifact-metadata:write` and storage record warnings are gone