### PR TITLE
docs: clarify model override example in ai-review readme

### DIFF
--- a/examples/ai-review/README.md
+++ b/examples/ai-review/README.md
@@ -54,7 +54,22 @@ jobs:
 ```
 
 `model`, `fallback_model`, `extra_instructions`, and `num_max_findings` all have sane defaults --
-override only the ones you need.
+override only the ones you need. Default `model` is `openai/internal/default`, i.e. the gateway's
+own internal default model (see [`ai-review.yaml`](../../.github/workflows/ai-review.yaml) for the
+current default). Keep the `openai/` prefix on any override -- litellm needs it to route through
+the gateway (`OPENAI.API_BASE`) instead of trying to call another provider's API directly:
+
+```yaml
+jobs:
+  ai-review:
+    uses: NethermindEth/github-workflows/.github/workflows/ai-review.yaml@stable
+    with:
+      model: openai/anthropic/claude-sonnet-5
+      fallback_model: openai/internal/default
+    secrets:
+      infisical_identity_id: ${{ secrets.INFISICAL_IDENTITY_ID }}
+      infisical_project_id: ${{ secrets.INFISICAL_PROJECT_ID }}
+```
 
 The `concurrency` block above is **your responsibility to declare**, not the reusable workflow's:
 concurrency groups are scoped per-repository, not per-workflow-file, so if the reusable workflow


### PR DESCRIPTION
## Summary

- Added an example showing how to override `model` and `fallback_model` on `ai-review.yaml`
- Noted the default is `openai/internal/default` (the gateway's own internal default), pointing at the workflow file for the current value
- Reiterated the `openai/` prefix requirement in the example -- litellm needs it to route through the gateway instead of hitting another provider directly (this was the bug behind AUT-427 / #163)

## Test plan

- [x] YAML code blocks in the README parse
- [x] Model default confirmed against the current `ai-review.yaml` on main