### PR TITLE
fix(docker-promote-jfrog): drop oras cp -r, JFrog 403s the Referrers API

### DIFF
--- a/.github/workflows/docker-promote-jfrog.yaml
+++ b/.github/workflows/docker-promote-jfrog.yaml
@@ -137,7 +137,10 @@ jobs:
             target_image="${TARGET_IMAGE}:${TAG}"
             echo "Promoting ${source_image} to ${target_image}"
 
-            oras cp -r ${source_image} ${target_image}
+            # No -r: it walks the OCI Referrers API, which nethermind.jfrog.io
+            # answers 403 (GET /v2/<repo>/referrers/<digest>), failing every promote.
+            # The Attest step below re-attests the target, so provenance is preserved.
+            oras cp ${source_image} ${target_image}
 
             # Get image digest and add it to the subject.checksums.txt file
             DIGEST=$(docker buildx imagetools inspect "${target_image}" --raw | sha256sum | cut -d' ' -f1)


### PR DESCRIPTION
Every JFrog promote has failed since ~2026-08-13 with `Error response from registry: : Forbidden`.

`oras cp -r` walks the OCI Referrers API. An `oras cp -r --debug` run names the failing call:

```
GET "https://nethermind.jfrog.io/v2/operations-oci-local-dev/ap-docs/referrers/sha256:57b11523..."
  -> response status code 403: : Forbidden
```

Not authz on the target: login succeeds, and plain `oras cp` promotes into `operations-oci-local-prod` with the same OIDC identity and even pushes an attestation there ([citizen-automations run 32815314246](https://github.com/NethermindEth/citizen-automations/actions/runs/32815314246), 2026-08-25). Only `-r` touches the referrers endpoint. It worked 2026-08-06 and has 403'd since — something changed Artifactory-side, and that is still worth a look, but promotes are blocked until then.

Tradeoff: referrers on the source image no longer follow. The `Attest` step re-attests the target with `push-to-registry: true`, so the promoted image still carries build provenance.

Validated: `citizen-automations@feat/promote-workflow` has run this exact command inlined since 2026-08-14 — 7 consecutive successful prod promotes (ap-docs, agent-intake).

Ref: [AUT-418](https://linear.app/nethermind/issue/AUT-418/promote-jake-to-prod-prod-image-frozen-since-2026-08-06-with-an)
