### PR TITLE
fix(ai-review): accept LITELLM_API_KEY as fallback for OPENAI.KEY

### DIFF
--- a/.github/workflows/ai-review-command.yaml
+++ b/.github/workflows/ai-review-command.yaml
@@ -105,10 +105,13 @@ jobs:
       # CONFIG.TEMPERATURE this would call the real OpenAI API with a gateway key and fail auth.
       # These env vars WIN over a repo-local .pr_agent.toml for any key they both set (confirmed
       # empirically, AUT-427) -- use the workflow inputs for overrides, not a toml.
+      # OPENAI.KEY tries both key names Infisical uses across different secret paths: the shared
+      # /apps/litellm/code-reviewer-prod folder names it LITELLM_API_KEY, a per-repo
+      # /github/workflows/<repo> folder (citizen-automations' convention) names it LLM_API_KEY.
       - name: PR-Agent -- run the commented command
         uses: the-pr-agent/pr-agent@f6af7d77554ff8d26adffded077e6461329e92fa # v0.42.0
         env:
-          OPENAI.KEY: ${{ env.LLM_API_KEY }}
+          OPENAI.KEY: ${{ env.LITELLM_API_KEY || env.LLM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AGENT_CONFIG_BRANCH: ${{ steps.pr_base.outputs.base_ref }}
           OPENAI.API_BASE: "https://litellm.nethermind.dev/v1" # non-secret; KEY comes from above

--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -99,9 +99,12 @@ jobs:
         with:
           persist-credentials: false
 
-      # Loads the org LiteLLM gateway credentials. Exports LLM_API_KEY and LLM_BASE_URL into the
-      # job env. Skipped for the configured skip_actor (e.g. Dependabot only gets Dependabot
-      # secrets, so the two Infisical ids would arrive empty and fail the whole job).
+      # Loads the org LiteLLM gateway credentials. The secret's key name is NOT consistent across
+      # Infisical paths: the shared /apps/litellm/code-reviewer-prod folder names it
+      # LITELLM_API_KEY, while a per-repo /github/workflows/<repo> folder (citizen-automations'
+      # convention) names it LLM_API_KEY -- OPENAI.KEY below tries both so either layout works.
+      # Skipped for the configured skip_actor (e.g. Dependabot only gets Dependabot secrets, so
+      # the two Infisical ids would arrive empty and fail the whole job).
       - name: Load gateway secrets from Infisical
         if: github.actor != inputs.skip_actor
         # Full owner/repo reference, not a relative path: a reusable workflow called from a
@@ -132,7 +135,7 @@ jobs:
         timeout-minutes: 20
         uses: the-pr-agent/pr-agent@f6af7d77554ff8d26adffded077e6461329e92fa # v0.42.0
         env:
-          OPENAI.KEY: ${{ env.LLM_API_KEY }}
+          OPENAI.KEY: ${{ env.LITELLM_API_KEY || env.LLM_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AGENT_CONFIG_BRANCH: ${{ github.base_ref }}
           OPENAI.API_BASE: "https://litellm.nethermind.dev/v1" # non-secret; KEY comes from above

--- a/examples/ai-review/README.md
+++ b/examples/ai-review/README.md
@@ -8,8 +8,13 @@ pattern running in `citizen-automations` today.
 
 1. **Org secrets** on the consuming repo (or org-wide): `INFISICAL_IDENTITY_ID`,
    `INFISICAL_PROJECT_ID`.
-2. **Infisical**: store `LLM_API_KEY` and `LLM_BASE_URL` at `/github/workflows/<your-repo-name>`
-   in the environment you pass as `env_slug` (default `prod`).
+2. **Infisical**: either use the shared gateway credential at `/apps/litellm/code-reviewer-prod`
+   (key `LITELLM_API_KEY`, project `angkor-ai-platform`) by passing `secret_path:
+   /apps/litellm/code-reviewer-prod`, or store your own `LLM_API_KEY` at
+   `/github/workflows/<your-repo-name>` (the default `secret_path`) in the environment you pass
+   as `env_slug` (default `prod`). The gateway API base is hardcoded in the workflow
+   (`https://litellm.nethermind.dev/v1`), not read from Infisical, so `LLM_BASE_URL` isn't needed
+   either way. `OPENAI.KEY` tries `LITELLM_API_KEY` then `LLM_API_KEY`, so either naming works.
 3. **Label**: create a `needs-human-review` label on the repo (or pass a different `label` input).
 4. Add the required status check in branch protection on your default branch. **The check name is
    `<your-job-id> / ai-review`, not `ai-review`** -- GitHub prefixes a reusable-workflow job's


### PR DESCRIPTION
## Summary

- `access-gateway`/`access-policy` rollout (AUT-444) failed twice: neither repo has `LLM_API_KEY` at citizen-automations' per-repo Infisical path, that's not an org-wide convention
- checked Infisical directly (phs secrets tool): the actual shared org credential lives at `/apps/litellm/code-reviewer-prod` in the `angkor-ai-platform` project, key named `LITELLM_API_KEY`, not `LLM_API_KEY`
- changed `OPENAI.KEY` in `ai-review.yaml` and `ai-review-command.yaml` to `${{ env.LITELLM_API_KEY || env.LLM_API_KEY }}` -- both naming conventions work, citizen-automations keeps working unchanged, new repos can point `secret_path` at the shared credential instead of provisioning their own
- noted `LLM_BASE_URL` was never actually needed -- the gateway API base is hardcoded in the workflow, not read from Infisical
- updated `examples/ai-review/README.md` setup section to document both options

## Test plan

- [x] YAML valid on both files
- [ ] confirm on a live PR (access-gateway#53 / access-policy#9, pinned to this commit) that the ai-review job actually authenticates and posts a review