### PR TITLE
diagnostic: route ai-review model at serialized alias

### DIFF
--- a/.github/workflows/ai-review.yaml
+++ b/.github/workflows/ai-review.yaml
@@ -22,10 +22,19 @@ on:
         # provided". "openai/" is what routes through OPENAI.API_BASE (our gateway) below --
         # dropping the prefix, or using another provider's own prefix (e.g. "gemini/"), makes
         # litellm try to call that provider's real API directly, bypassing the gateway entirely.
+        #
+        # TEMP DIAGNOSTIC (2026-08-26): pointed at internal/ai-review, not internal/default.
+        # Same backend, but the gateway sets max_parallel_requests: 1 on this alias -- PR-Agent
+        # runs its describe/review sub-calls concurrently (async_ai_calls, max_ai_calls: 4), and
+        # a slow ai-review run showed 2-4 concurrent requests to the box for its whole 10min+
+        # duration. This forces the gateway to serialize calls, to test whether GPU contention
+        # (not the LLM being genuinely stuck) is driving the multi-minute-plus generations.
+        # Revert to "openai/internal/default" once the test has an answer (argocd repo also has
+        # a matching revert: drop the internal/ai-review model_list entry).
         description: "Gateway model PR-Agent uses for review/describe/improve (keep the openai/ prefix)"
         type: string
         required: false
-        default: "openai/internal/default"
+        default: "openai/internal/ai-review"
       fallback_model:
         # Same "openai/" prefix requirement as `model` above -- see that comment.
         description: "Gateway fallback model if the primary model call fails (keep the openai/ prefix)"


### PR DESCRIPTION
## Summary

companion to the argocd PR adding `internal/ai-review`. this just flips the default `model` input here from `openai/internal/default` to `openai/internal/ai-review`.

context: ai-review jobs keep hitting Cloudflare 524 + the 20min GH Actions timeout, even after the litellm proxy timeout fix and vLLM auth (both already merged, separate PRs). latest run, /describe succeeded in 113s, then /review's first attempt ran 10+ minutes before the same 524, retry got killed by the job's own 20min timeout before finishing.

pulled up the new Grafana dashboard for that exact window and `vllm:num_requests_running` was 1-4 concurrent the whole time, that's confirmed from metrics not a guess. PR-Agent fires describe/review sub-calls concurrently (async_ai_calls, max_ai_calls: 4), so that lines up.

almost blamed missing max_tokens cap too (saw max_tokens=240758 on a request), but the actual failed request never finished so there's no token count to point at, can't claim that one. concurrency is the only thing the metrics actually back up, so that's the one being tested here.

not claiming this fixes anything yet, it's a controlled test scoped to this workflow only (internal/ai-review is a brand new alias, doesn't touch internal/default or anyone else using it).

## Test plan
- [ ] watch the next few ai-review runs on citizen-automations, compare /review duration against the 10min+ ones seen before
- [ ] pull `vllm:num_requests_running` for those windows, should stay at 1 given max_parallel_requests: 1
- [ ] fast + no 524 = contention confirmed as the cause, still slow with concurrency at 1 = rule it out, look elsewhere
- [ ] revert this default back to `openai/internal/default` (and drop the argocd model_list entry) once there's an answer

https://claude.ai/code/session_011fL41Xf26GymoESHhy45t8